### PR TITLE
support for custom executable

### DIFF
--- a/docs/sultan-examples.rst
+++ b/docs/sultan-examples.rst
@@ -220,3 +220,26 @@ with Sultan.load() as s:
 Most times, you don't need to access the results of a command, but there are 
 times that you need to do so. For that, the **Result** object will be how you
 access it.
+
+Example 13: Custom Executable
+----------------------------------
+
+By default python's `subprocess <https://docs.python.org/3/library/subprocess.html#popen-constructor>`
+executes the program through **/bin/sh** on POSIX systems. In the rare circumstances
+when that's not desired, you can change it with the 'executable' argument while
+loading Sultan with Context.
+
+Here is an example::
+
+
+Here is an example that shows how to get the results of a command::
+
+    with Sultan.load(executable='/bin/bash') as sultan_bash:
+
+        result = sultan_bash.ps('-p', '$$', '-ocomm=')
+        assert result == 'bash'
+
+    with Sultan.load(executable='/bin/dash') as sultan_other:
+
+        result = sultan_other.ps('-p', '$$', '-ocomm=')
+        assert result == 'dash'

--- a/src/sultan/api.py
+++ b/src/sultan/api.py
@@ -77,7 +77,8 @@ class Sultan(Base):
     @classmethod
     def load(cls, 
         cwd=None, sudo=False, user=None, 
-        hostname=None, env=None, logging=True, 
+        hostname=None, env=None, logging=True,
+        executable=None,
         ssh_config=None, src=None, 
         **kwargs):
 
@@ -90,6 +91,9 @@ class Sultan(Base):
         if src and not os.path.exists(src):
             raise IOError("The Source File provided (%s) does not exist" % src)
 
+        if executable and not os.path.exists(executable):
+            raise IOError("The set Executable (%s) does not exist" % src)
+
         context = {}
         context['cwd'] = cwd
         context['sudo'] = sudo
@@ -98,6 +102,7 @@ class Sultan(Base):
         context['env'] = env or None # must be None, for Python to get the current process's env.
         context['logging'] = logging
         context['src'] = src
+        context['executable'] = executable
 
         # determine user
         if user:
@@ -191,7 +196,7 @@ class Sultan(Base):
 
         stdout, stderr = None, None
         env = self._context[0].get('env', {}) if len(self._context) > 0 else os.environ
-
+        executable = self.current_context.get('executable')
         try:
             stdout, stderr = subprocess.Popen(commands,
                                               shell=True,
@@ -199,6 +204,7 @@ class Sultan(Base):
                                               stdin=subprocess.PIPE,
                                               stdout=subprocess.PIPE,
                                               stderr=subprocess.PIPE,
+                                              executable=executable,
                                               universal_newlines=True).communicate()
             result = Result(stdout, stderr)
 

--- a/test/integration/sultan/test_api.py
+++ b/test/integration/sultan/test_api.py
@@ -59,7 +59,7 @@ class SultanExecutable(unittest.TestCase):
 
     def test_nonexistent_executable(self):
         with self.assertRaises(IOError):
-            with Sultan.load(executable='/bin/sh') as sultan:
+            with Sultan.load(executable='no_such_exe_cause_sultan') as sultan:
                 sultan.ls().run()
 
 

--- a/test/integration/sultan/test_api.py
+++ b/test/integration/sultan/test_api.py
@@ -39,6 +39,30 @@ class SultanEnvironment(unittest.TestCase):
             response = s.env().run()
             self.assertIn('FOOBAR=/tmp', response.stdout)
 
+
+class SultanExecutable(unittest.TestCase):
+    """
+    Tests for the executable being used
+    """
+
+    def test_default_executable(self):
+
+        with Sultan.load() as sultan:
+            result = sultan.ps().pipe().grep('`echo $$`').pipe().awk("'{ print $4 }'").run()
+            self.assertEqual(result.stdout[0], 'sh')
+
+    def test_custom_executable(self):
+
+        with Sultan.load(executable='/bin/bash') as sultan:
+            result = sultan.ps().pipe().grep('`echo $$`').pipe().awk("'{ print $4 }'").run()
+            self.assertEqual(result.stdout[0], 'bash')
+
+    def test_nonexistent_executable(self):
+        with self.assertRaises(IOError):
+            with Sultan.load(executable='/bin/sh') as sultan:
+                sultan.ls().run()
+
+
 class SultanRunCustomScripts(unittest.TestCase):
     """
     Run a custom script that we create

--- a/test/unit/sultan/test_api.py
+++ b/test/unit/sultan/test_api.py
@@ -131,6 +131,7 @@ class SultanTestCase(unittest.TestCase):
         self.assertEqual(sultan.current_context, {
             'cwd': '/tmp',
             'env': None,
+            'executable': None,
             'sudo': False,
             'logging': True,
             'test_key': 'test_val',
@@ -144,7 +145,8 @@ class SultanTestCase(unittest.TestCase):
         with Sultan.load(cwd='/tmp') as sultan:
             self.assertEqual(sultan.current_context, {
                 'cwd': '/tmp', 
-                'env': None, 
+                'env': None,
+                'executable': None,
                 'sudo': False, 
                 'logging': True, 
                 'user': getpass.getuser(), 
@@ -157,7 +159,8 @@ class SultanTestCase(unittest.TestCase):
         with Sultan.load(cwd='/tmp', sudo=True) as sultan:
             self.assertEqual(sultan.current_context, {
                 'cwd': '/tmp', 
-                'env': None, 
+                'env': None,
+                'executable': None,
                 'sudo': True, 
                 'logging': True, 
                 'user': getpass.getuser(), 
@@ -169,7 +172,8 @@ class SultanTestCase(unittest.TestCase):
         with Sultan.load(cwd='/tmp', sudo=False, user="hodor") as sultan:
             self.assertEqual(sultan.current_context, {
                 'cwd': '/tmp', 
-                'env': None, 
+                'env': None,
+                'executable': None,
                 'sudo': False, 
                 'logging': True, 
                 'user': 'hodor', 
@@ -183,6 +187,7 @@ class SultanTestCase(unittest.TestCase):
             self.assertEqual(sultan.current_context, {
                 'cwd': None,
                 'env': None,
+                'executable': None,
                 'sudo': True, 
                 'logging': True, 
                 'user': getpass.getuser(), 
@@ -196,7 +201,8 @@ class SultanTestCase(unittest.TestCase):
             
             self.assertEqual(sultan.current_context, {
                 'cwd': None, 
-                'env': None, 
+                'env': None,
+                'executable': None,
                 'sudo': False, 
                 'logging': True, 
                 'user': getpass.getuser(), 
@@ -209,7 +215,8 @@ class SultanTestCase(unittest.TestCase):
         with Sultan.load(env={'path': ''}) as sultan:
             self.assertEqual(sultan.current_context, {
                 'cwd': None, 
-                'env': {'path': ''}, 
+                'env': {'path': ''},
+                'executable': None,
                 'sudo': False, 
                 'logging': True, 
                 'user': getpass.getuser(), 
@@ -224,6 +231,7 @@ class SultanTestCase(unittest.TestCase):
             self.assertEqual(sultan.current_context, {
                 'cwd': None,
                 'env': None,
+                'executable': None,
                 'sudo': False,
                 'logging': True,
                 'user': getpass.getuser(),
@@ -239,6 +247,7 @@ class SultanTestCase(unittest.TestCase):
                 self.assertEqual(s.current_context, {
                     'cwd': None,
                     'env': None,
+                    'executable': None,
                     'sudo': False,
                     'logging': True,
                     'user': getpass.getuser(),
@@ -250,6 +259,24 @@ class SultanTestCase(unittest.TestCase):
             if os.path.exists(filepath):
                 os.unlink(filepath)
 
+        # custom executable
+        filehandle, filepath = tempfile.mkstemp()
+        try:
+            with Sultan.load(executable=filepath) as s:
+                self.assertEqual(s.current_context, {
+                    'cwd': None,
+                    'env': None,
+                    'executable': filepath,
+                    'sudo': False,
+                    'logging': True,
+                    'user': getpass.getuser(),
+                    'hostname': None,
+                    'ssh_config': '',
+                    'src': None
+                })
+        finally:
+            if os.path.exists(filepath):
+                os.unlink(filepath)
 
     def test_context_for_pwd(self):
 


### PR DESCRIPTION
Adds a new `executable` argument to `load()`, the value of which is the actual shell to use for the execution. Default value is None, preserving the current behavior to run through `/bin/sh` (on POSIX systems).

Fixes #50 