### PR TITLE
FEAT store the command's RC in the Result object

### DIFF
--- a/docs/sultan-examples.rst
+++ b/docs/sultan-examples.rst
@@ -202,8 +202,8 @@ Example 12: Results from a Command
 ----------------------------------
 
 When you run a command, your shell gives back results in stdout and stderr.
-Sultan returns a Result object which has **stdout**, **stderr** and 
-**traceback** object. 
+Sultan returns a Result object which has **stdout**, **stderr**,
+**traceback** and **rc** attributes.
 
 Here is an example that shows how to get the results of a command::
 
@@ -213,9 +213,10 @@ with Sultan.load() as s:
     result.stdout # the stdout
     result.stderr # the stderr
     result.traceback # the traceback
+    result.rc # the return code
 
 **stdout** and **stderr** returns a list, where each element is a line from 
-**stdout** and **stderr**.
+**stdout** and **stderr**; **rc** is an integer.
 
 Most times, you don't need to access the results of a command, but there are 
 times that you need to do so. For that, the **Result** object will be how you

--- a/src/sultan/api.py
+++ b/src/sultan/api.py
@@ -193,14 +193,16 @@ class Sultan(Base):
         env = self._context[0].get('env', {}) if len(self._context) > 0 else os.environ
 
         try:
-            stdout, stderr = subprocess.Popen(commands,
-                                              shell=True,
-                                              env=env,
-                                              stdin=subprocess.PIPE,
-                                              stdout=subprocess.PIPE,
-                                              stderr=subprocess.PIPE,
-                                              universal_newlines=True).communicate()
-            result = Result(stdout, stderr)
+            process = subprocess.Popen(commands,
+                                       shell=True,
+                                       env=env,
+                                       stdin=subprocess.PIPE,
+                                       stdout=subprocess.PIPE,
+                                       stderr=subprocess.PIPE,
+                                       universal_newlines=True)
+
+            stdout, stderr = process.communicate()
+            result = Result(stdout, stderr, rc=process.returncode)
 
             if result.stdout:
                 return result 

--- a/src/sultan/result.py
+++ b/src/sultan/result.py
@@ -6,12 +6,13 @@ class Result(Base):
     Class that encompasses the result of a POpen command.
     """
 
-    def __init__(self, stdout, stderr, traceback=None):
+    def __init__(self, stdout, stderr, traceback=None, rc=None):
 
         super(Result, self).__init__()        
         self.__stdout = stdout
         self.__stderr = stderr
         self.__traceback = traceback
+        self.rc = rc
         self.__echo = Echo()
 
     def __str__(self):

--- a/test/integration/sultan/test_api.py
+++ b/test/integration/sultan/test_api.py
@@ -78,3 +78,19 @@ echo 'Donec sapien turpis, mattis vel urna sed, iaculis aliquam purus.\n' > $OUT
             self.assertEqual(response.stdout, ['Donec sapien turpis, mattis vel urna sed, iaculis aliquam purus.'])
         finally:
             shutil.rmtree(self.dir_path)
+
+
+class SultanReturnCode(unittest.TestCase):
+    """
+    Checks on the rc (return code).
+    """
+
+    def test_zero_rc(self):
+        with Sultan.load() as s:
+            response = s.ls().run()
+            self.assertEqual(response.rc, 0)
+
+    def test_non_zero_rc(self):
+        with Sultan.load() as s:
+            response = s.exit(22).run()
+            self.assertEqual(response.rc, 22)


### PR DESCRIPTION
Fixes #52 - the RC of an executed command is now a Result attribute - `rc`, accessible on flow control return.