### PR TITLE
Result.print_*() to pass by default if their buffers are empty

### DIFF
--- a/src/sultan/result.py
+++ b/src/sultan/result.py
@@ -1,6 +1,7 @@
 from sultan.core import Base
 from sultan.echo import Echo
 
+
 class Result(Base):
     """
     Class that encompasses the result of a POpen command.
@@ -30,47 +31,53 @@ class Result(Base):
 
     @property
     def stdout(self):
-        '''
+        """
         Converts stdout string to a list.
-        '''
+        """
         return self.__stdout.strip().splitlines() if self.__stdout else ''
 
     @property
     def stderr(self):
-        '''
+        """
         Converts stderr string to a list.
-        '''
+        """
         return self.__stderr.strip().splitlines() if self.__stderr else ''
 
     @property
     def traceback(self):
-        '''
+        """
         Converts traceback string to a list.
-        '''
+        """
         return self.__traceback
 
-    def print_stdout(self):
-        '''
-        Prints the stdout to console
-        '''
-        self.__echo.critical("--{ STDOUT }---" + "-" * 100)
-        self.__format_lines(self.stdout)
-        self.__echo.critical("---------------" + "-" * 100)
+    def print_stdout(self, always_print=False):
+        """
+        Prints the stdout to console - if there is any stdout, otherwise does nothing.
+        :param always_print:   print the stdout, even if there is nothing in the buffer (default: false)
+        """
+        if self.stdout or always_print:
+            self.__echo.critical("--{ STDOUT }---" + "-" * 100)
+            self.__format_lines(self.stdout)
+            self.__echo.critical("---------------" + "-" * 100)
 
-    def print_stderr(self):
-        '''
-        Prints the stderr to console
-        '''
-        self.__echo.critical("--{ STDERR }---" + "-" * 100)
-        self.__format_lines(self.stderr)
-        self.__echo.critical("---------------" + "-" * 100)
+    def print_stderr(self, always_print=False):
+        """
+        Prints the stderr to console - if there is any stdout, otherwise does nothing.
+        :param always_print:   print the stderr, even if there is nothing in the buffer (default: false)
+        """
+        if self.stderr or always_print:
+            self.__echo.critical("--{ STDERR }---" + "-" * 100)
+            self.__format_lines(self.stderr)
+            self.__echo.critical("---------------" + "-" * 100)
 
-    def print_traceback(self):
-        '''
-        Prints the traceback to console
-        '''
-        self.__echo.critical("--{ TRACEBACK }" + "-" * 100)
-        self.__format_lines(self.traceback)
-        self.__echo.critical("---------------" + "-" * 100)
+    def print_traceback(self, always_print=False):
+        """
+        Prints the traceback to console - if there is any traceback, otherwise does nothing.
+        :param always_print:   print the traceback, even if there is nothing in the buffer (default: false)
+        """
+        if self.traceback or always_print:
+            self.__echo.critical("--{ TRACEBACK }" + "-" * 100)
+            self.__format_lines(self.traceback)
+            self.__echo.critical("---------------" + "-" * 100)
 
 


### PR DESCRIPTION
If the `Result`'s `stdout`, `stderr` and `traceback` don't have anything, the corresponding print method will not output anything; there's an argument `always_print` with default value `False`, to have the old behavior.

The user benefit of the change is a shortcut for constructs like this:

    if sultan.stdout:
        sultan.print_stdout()


_Also in the PR - docstrings with doublequotes :)_