### PR TITLE
[SSHConfig] Allow ssh options to be specified

### DIFF
--- a/src/sultan/api.py
+++ b/src/sultan/api.py
@@ -581,6 +581,10 @@ class SSHConfig(Config):
             'shorthand': '-i',
             'required': False
         },
+        'option': {
+            'shorthand': '-o',
+            'required': False
+        },
         'port': {
             'shorthand': '-p',
             'required': False


### PR DESCRIPTION
Added '-o' to be able to specify options in ssh commands.