### PR TITLE
Add a flag to ignore Popen from capturing stdout/stderr

### DIFF
--- a/src/sultan/api.py
+++ b/src/sultan/api.py
@@ -79,7 +79,7 @@ class Sultan(Base):
         cwd=None, sudo=False, user=None, 
         hostname=None, env=None, logging=True,
         executable=None,
-        ssh_config=None, src=None, 
+        ssh_config=None, src=None, capture_output=True,
         **kwargs):
 
         # initial checks
@@ -103,6 +103,7 @@ class Sultan(Base):
         context['logging'] = logging
         context['src'] = src
         context['executable'] = executable
+        context['capture_output'] = capture_output
 
         # determine user
         if user:
@@ -114,7 +115,6 @@ class Sultan(Base):
         return cls(context=context)
 
     def __init__(self, context=None):
-
         self.commands = []
         self._context = [context] if context is not None else []
         self.logging_activated = context.get('logging') if context else False
@@ -202,13 +202,14 @@ class Sultan(Base):
         stdout, stderr = None, None
         env = self._context[0].get('env', {}) if len(self._context) > 0 else os.environ
         executable = self.current_context.get('executable')
+        capture_output = self._context[0]['capture_output'] if len(self._context) > 0 else True 
         try:
             process = subprocess.Popen(commands,
                                        shell=True,
                                        env=env,
                                        stdin=subprocess.PIPE,
-                                       stdout=subprocess.PIPE,
-                                       stderr=subprocess.PIPE,
+                                       stdout=subprocess.PIPE if capture_output else None,
+                                       stderr=subprocess.PIPE if capture_output else None,
                                        executable=executable,
                                        universal_newlines=True)
 
@@ -396,6 +397,7 @@ class Sultan(Base):
         echo_debug_info('executable')
         echo_debug_info('ssh_config')
         echo_debug_info('src')
+        echo_debug_info('capture_output')
 
 class BaseCommand(Base):
     """

--- a/test/integration/sultan/test_api.py
+++ b/test/integration/sultan/test_api.py
@@ -49,13 +49,13 @@ class SultanExecutable(unittest.TestCase):
 
         with Sultan.load() as sultan:
             result = sultan.ps().pipe().grep('`echo $$`').pipe().awk("'{ print $4 }'").run()
-            self.assertEqual(result.stdout[0], 'sh')
+            self.assertEqual(result.stdout[0], '/bin/sh')
 
     def test_custom_executable(self):
 
         with Sultan.load(executable='/bin/bash') as sultan:
             result = sultan.ps().pipe().grep('`echo $$`').pipe().awk("'{ print $4 }'").run()
-            self.assertEqual(result.stdout[0], 'bash')
+            self.assertEqual(result.stdout[0], '/bin/bash')
 
     def test_nonexistent_executable(self):
         with self.assertRaises(IOError):

--- a/test/integration/sultan/test_api.py
+++ b/test/integration/sultan/test_api.py
@@ -49,13 +49,13 @@ class SultanExecutable(unittest.TestCase):
 
         with Sultan.load() as sultan:
             result = sultan.ps().pipe().grep('`echo $$`').pipe().awk("'{ print $4 }'").run()
-            self.assertEqual(result.stdout[0], '/bin/sh')
+            self.assertEqual(result.stdout[0], 'sh')
 
     def test_custom_executable(self):
 
         with Sultan.load(executable='/bin/bash') as sultan:
             result = sultan.ps().pipe().grep('`echo $$`').pipe().awk("'{ print $4 }'").run()
-            self.assertEqual(result.stdout[0], '/bin/bash')
+            self.assertEqual(result.stdout[0], 'bash')
 
     def test_nonexistent_executable(self):
         with self.assertRaises(IOError):

--- a/test/unit/sultan/test_api.py
+++ b/test/unit/sultan/test_api.py
@@ -138,7 +138,8 @@ class SultanTestCase(unittest.TestCase):
             'user': getpass.getuser(),
             'hostname': None,
             'ssh_config': '',
-            'src': None
+            'src': None,
+            'capture_output': True,
         })
 
         # cwd
@@ -152,7 +153,8 @@ class SultanTestCase(unittest.TestCase):
                 'user': getpass.getuser(), 
                 'hostname': None,
                 'ssh_config': '',
-                'src': None
+                'src': None,
+                'capture_output': True,
             })
 
         # sudo
@@ -166,7 +168,8 @@ class SultanTestCase(unittest.TestCase):
                 'user': getpass.getuser(), 
                 'hostname': None,
                 'ssh_config': '',
-                'src': None
+                'src': None,
+                'capture_output': True,
             })
 
         with Sultan.load(cwd='/tmp', sudo=False, user="hodor") as sultan:
@@ -179,7 +182,8 @@ class SultanTestCase(unittest.TestCase):
                 'user': 'hodor', 
                 'hostname': None,
                 'ssh_config': '',
-                'src': None
+                'src': None,
+                'capture_output': True,
             })
 
         with Sultan.load(sudo=True) as sultan:
@@ -193,7 +197,8 @@ class SultanTestCase(unittest.TestCase):
                 'user': getpass.getuser(), 
                 'hostname': None,
                 'ssh_config': '',
-                'src': None
+                'src': None,
+                'capture_output': True,
             })
 
         # hostname
@@ -208,7 +213,8 @@ class SultanTestCase(unittest.TestCase):
                 'user': getpass.getuser(), 
                 'hostname': 'localhost',
                 'ssh_config': '',
-                'src': None
+                'src': None,
+                'capture_output': True,
             })
 
         # set environment
@@ -222,9 +228,25 @@ class SultanTestCase(unittest.TestCase):
                 'user': getpass.getuser(), 
                 'hostname': None,
                 'ssh_config': '',
-                'src': None
+                'src': None,
+                'capture_output': True,
             })
 
+        # disable capture of stdout/stderr
+        with Sultan.load(capture_output=False) as sultan:
+            self.assertEqual(sultan.current_context, {
+                'cwd': None,
+                'env': None,
+                'executable': None,
+                'sudo': False,
+                'logging': True,
+                'user': getpass.getuser(),
+                'hostname': None,
+                'ssh_config': '',
+                'src': None,
+                'capture_output': False,
+            })
+            
         # set port
         config = SSHConfig(port=2222)
         with Sultan.load(ssh_config=config) as sultan:
@@ -237,7 +259,8 @@ class SultanTestCase(unittest.TestCase):
                 'user': getpass.getuser(),
                 'hostname': None,
                 'ssh_config': '-p 2222',
-                'src': None
+                'src': None,
+                'capture_output': True,
             })
 
         # set src
@@ -253,7 +276,8 @@ class SultanTestCase(unittest.TestCase):
                     'user': getpass.getuser(),
                     'hostname': None,
                     'ssh_config': '',
-                    'src': filepath
+                    'src': filepath,
+                    'capture_output': True,
                 })
         finally:
             if os.path.exists(filepath):
@@ -272,7 +296,8 @@ class SultanTestCase(unittest.TestCase):
                     'user': getpass.getuser(),
                     'hostname': None,
                     'ssh_config': '',
-                    'src': None
+                    'src': None,
+                    'capture_output': True,
                 })
         finally:
             if os.path.exists(filepath):


### PR DESCRIPTION
Hi,

In some situations, I do not want Sultan to capture the output of a process and instead make it go directly to the terminal. This PR adds a flag the sets stdout/err to `None` when opening the process. 

Regards