### PR TITLE
Code block in example 12 not rendering as code

### DIFF
--- a/docs/sultan-examples.rst
+++ b/docs/sultan-examples.rst
@@ -207,13 +207,13 @@ Sultan returns a Result object which has **stdout**, **stderr**,
 
 Here is an example that shows how to get the results of a command::
 
-with Sultan.load() as s:
+    with Sultan.load() as s:
 
-    result = s.yum('install', '-y', 'postgresql')
-    result.stdout # the stdout
-    result.stderr # the stderr
-    result.traceback # the traceback
-    result.rc # the return code
+        result = s.yum('install', '-y', 'postgresql')
+        result.stdout # the stdout
+        result.stderr # the stderr
+        result.traceback # the traceback
+        result.rc # the return code
 
 **stdout** and **stderr** returns a list, where each element is a line from 
 **stdout** and **stderr**; **rc** is an integer.


### PR DESCRIPTION
The code block in example 12 was not rendering as code, and the line breaks were not being respected. This issue was also showing up in the readthedocs version. I indented the whole block after the :: so that it would be rendered as code. 