### PR TITLE
Add the ssh options flag back in

### DIFF
--- a/src/sultan/api.py
+++ b/src/sultan/api.py
@@ -532,4 +532,8 @@ class SSHConfig(Config):
             'shorthand': '-p',
             'required': False
         },
+        'option': {
+            'shorthand': '-o',
+            'required': False
+        },
     }


### PR DESCRIPTION
This was originally added in https://github.com/aeroxis/sultan/pull/65

And seemingly removed by https://github.com/aeroxis/sultan/pull/71/files#diff-b40d03f22a7fbe9af83a379b51281fb7L584

As far as i can tell by looking at the changeset of #71 I don't think this was in intentional change.